### PR TITLE
opaquely paged blob listing

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -1,4 +1,5 @@
 import typing
+import types
 
 
 class PagedIter(typing.Iterable[str]):
@@ -42,15 +43,21 @@ class PagedIter(typing.Iterable[str]):
             listing = self.get_listing_from_response(resp)
 
             if self.start_after_key:
-                for key in listing:
+                while True:
+                    try:
+                        key = next(listing)
+                    except StopIteration:
+                        raise BlobPagingError('Marker not found in this page')
+
                     if key == self.start_after_key:
                         break
-                else:
-                    raise BlobPagingError('Marker not found in this page')
 
-            for key in listing:
-                self.start_after_key = key
-                yield self.start_after_key
+            while True:
+                try:
+                    self.start_after_key = next(listing)
+                    yield self.start_after_key
+                except StopIteration:
+                    break
 
             self.start_after_key = None
 

--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -92,7 +92,7 @@ class BlobStore:
             start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
-    ) -> typing.Iterator[str]:
+    ) -> typing.Iterable[str]:
         """
         Returns an iterator of all blob entries in a bucket that match a given prefix.  Do not return any keys that
         contain the delimiter past the prefix.

--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -6,8 +6,6 @@ class PagedIter(typing.Iterable[str]):
     Provide an iterator that will iterate over every object, filtered by prefix and delimiter. Alternately continue
     iteration with token and key (marker).
     """
-    def __init__(self):
-        pass
 
     def get_api_response(self, next_token):
         """
@@ -50,8 +48,8 @@ class PagedIter(typing.Iterable[str]):
             for key in listing:
                 self.marker = key
                 yield self.marker
-            else:
-                self.marker = None
+
+            self.marker = None
 
             next_token = self.get_next_token_from_response(resp)
 

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -95,7 +95,7 @@ class GSBlobStore(BlobStore):
             start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
-    ):  # type typing.Iterable[str]:
+    ) -> typing.Iterable[str]:
         return GSPagedIter(
             self._ensure_bucket_loaded(bucket),
             prefix=prefix,

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -46,9 +46,7 @@ class GSPagedIter(PagedIter):
         return resp
 
     def get_listing_from_response(self, resp):
-        contents = list(resp)
-
-        return (b.name for b in contents)
+        return (b.name for b in resp)
 
     def get_next_token_from_response(self, resp):
         return resp.next_page_token

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -6,7 +6,53 @@ import typing
 from google.cloud.storage import Client
 from google.cloud.storage.bucket import Bucket
 
-from . import BlobNotFoundError, BlobStore
+from . import BlobNotFoundError, BlobStore, PagedIter
+
+
+class GSPagedIter(PagedIter):
+    def __init__(
+            self,
+            bucket_obj, # type: Bucket
+            prefix: str=None,
+            delimiter: str=None,
+            marker: str=None,
+            token: str=None,
+            k_page_max: int=None
+    ) -> typing.Iterator[str]:
+        self.bucket_obj = bucket_obj
+        self.marker = marker
+        self.token = token
+
+        self.kwargs = dict()
+
+        if prefix is not None:
+            self.kwargs['prefix'] = prefix
+
+        if delimiter is not None:
+            self.kwargs['delimiter'] = delimiter
+
+        if k_page_max is not None:
+            self.kwargs['max_results'] = k_page_max
+
+    def get_api_response(self, next_token=None):
+        kwargs = self.kwargs.copy()
+
+        if next_token is not None:
+            kwargs['page_token'] = next_token
+    
+        resp = self.bucket_obj.list_blobs(
+            ** kwargs
+        )
+
+        return resp
+
+    def get_listing_from_response(self, resp):
+        contents = list(resp)
+
+        return [b.name for b in contents]
+
+    def get_next_token_from_response(self, resp):
+        return resp.next_page_token
 
 
 class GSBlobStore(BlobStore):
@@ -43,6 +89,24 @@ class GSBlobStore(BlobStore):
         bucket_obj = self._ensure_bucket_loaded(bucket)
         for blob_obj in bucket_obj.list_blobs(**kwargs):
             yield blob_obj.name
+
+    def list_v2(
+            self,
+            bucket: str,
+            prefix: str=None,
+            delimiter: str=None,
+            marker: str=None,
+            token: str=None,
+            k_page_max: int=None
+    ) -> typing.Iterator[str]:
+        return GSPagedIter(
+            self._ensure_bucket_loaded(bucket),
+            prefix,
+            delimiter,
+            marker,
+            token,
+            k_page_max
+        )
 
     def generate_presigned_GET_url(
             self,

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -12,18 +12,19 @@ from . import BlobNotFoundError, BlobStore, PagedIter
 class GSPagedIter(PagedIter):
     def __init__(
             self,
-            bucket_obj, # type: Bucket
+            bucket_obj,  # type: Bucket
+            *,
             prefix: str=None,
             delimiter: str=None,
             marker: str=None,
             token: str=None,
             k_page_max: int=None
-    ) -> typing.Iterator[str]:
+    ) -> None:
         self.bucket_obj = bucket_obj
         self.marker = marker
         self.token = token
 
-        self.kwargs = dict()
+        self.kwargs = dict()  # type: dict
 
         if prefix is not None:
             self.kwargs['prefix'] = prefix
@@ -39,17 +40,15 @@ class GSPagedIter(PagedIter):
 
         if next_token is not None:
             kwargs['page_token'] = next_token
-    
-        resp = self.bucket_obj.list_blobs(
-            ** kwargs
-        )
+
+        resp = self.bucket_obj.list_blobs(**kwargs)
 
         return resp
 
     def get_listing_from_response(self, resp):
         contents = list(resp)
 
-        return [b.name for b in contents]
+        return (b.name for b in contents)
 
     def get_next_token_from_response(self, resp):
         return resp.next_page_token
@@ -98,14 +97,14 @@ class GSBlobStore(BlobStore):
             marker: str=None,
             token: str=None,
             k_page_max: int=None
-    ) -> typing.Iterator[str]:
+    ):  # type typing.Iterable[str]:
         return GSPagedIter(
             self._ensure_bucket_loaded(bucket),
-            prefix,
-            delimiter,
-            marker,
-            token,
-            k_page_max
+            prefix=prefix,
+            delimiter=delimiter,
+            marker=marker,
+            token=token,
+            k_page_max=k_page_max
         )
 
     def generate_presigned_GET_url(

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -12,7 +12,7 @@ from . import BlobNotFoundError, BlobStore, PagedIter
 class GSPagedIter(PagedIter):
     def __init__(
             self,
-            bucket_obj,  # type: Bucket
+            bucket_obj: Bucket,
             *,
             prefix: str=None,
             delimiter: str=None,

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -16,12 +16,12 @@ class GSPagedIter(PagedIter):
             *,
             prefix: str=None,
             delimiter: str=None,
-            marker: str=None,
+            start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
     ) -> None:
         self.bucket_obj = bucket_obj
-        self.marker = marker
+        self.start_after_key = start_after_key
         self.token = token
 
         self.kwargs = dict()  # type: dict
@@ -94,7 +94,7 @@ class GSBlobStore(BlobStore):
             bucket: str,
             prefix: str=None,
             delimiter: str=None,
-            marker: str=None,
+            start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
     ):  # type typing.Iterable[str]:
@@ -102,7 +102,7 @@ class GSBlobStore(BlobStore):
             self._ensure_bucket_loaded(bucket),
             prefix=prefix,
             delimiter=delimiter,
-            marker=marker,
+            start_after_key=start_after_key,
             token=token,
             k_page_max=k_page_max
         )

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -10,7 +10,64 @@ from . import (
     BlobStore,
     BlobStoreCredentialError,
     BlobStoreUnknownError,
+    PagedIter
 )
+
+
+class AWSPagedIter(PagedIter):
+    def __init__(
+            self,
+            bucket: str,
+            prefix: str=None,
+            delimiter: str=None,
+            marker: str=None,
+            token: str=None,
+            k_page_max: int=None
+    ) -> typing.Iterator[str]:
+        self.marker = marker
+        self.token = token
+        self.k_page_max = None
+
+        self.kwargs = {
+            'Bucket': bucket,
+        }
+
+        if prefix is not None:
+            self.kwargs['Prefix'] = prefix
+
+        if delimiter is not None:
+            self.kwargs['Delimiter'] = delimiter
+
+        if k_page_max is not None:
+            self.kwargs['MaxKeys'] = k_page_max
+
+    def get_api_response(self, next_token):
+        kwargs = self.kwargs.copy()
+
+        if next_token is not None:
+            kwargs['ContinuationToken'] = next_token
+    
+        resp = boto3.client('s3').list_objects_v2(
+            ** kwargs
+        )
+
+        return resp
+
+    def get_listing_from_response(self, resp):
+        if resp.get('Contents', None):
+            contents = resp['Contents']
+        else:
+            contents = list()
+
+        return [b['Key'] for b in contents]
+
+    def get_next_token_from_response(self, resp):
+        if resp['IsTruncated']:
+            token = resp['NextContinuationToken'] 
+        else:
+            token = None
+
+        return token
 
 
 class S3BlobStore(BlobStore):
@@ -46,6 +103,24 @@ class S3BlobStore(BlobStore):
                 objects.
                 filter(**kwargs)):
             yield item.key
+
+    def list_v2(
+            self,
+            bucket: str,
+            prefix: str=None,
+            delimiter: str=None,
+            marker: str=None,
+            token: str=None,
+            k_page_max: int=None
+    ) -> typing.Iterator[str]:
+        return AWSPagedIter(
+            bucket,
+            prefix,
+            delimiter,
+            marker,
+            token,
+            k_page_max
+        )        
 
     def generate_presigned_GET_url(
             self,

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -10,7 +10,7 @@ from . import (
     BlobStore,
     BlobStoreCredentialError,
     BlobStoreUnknownError,
-    PagedIter
+    PagedIter,
 )
 
 
@@ -110,7 +110,7 @@ class S3BlobStore(BlobStore):
             start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
-    ):  # type typing.Iterable[str]:
+    ) -> typing.Iterable[str]:
         return S3PagedIter(
             bucket,
             prefix=prefix,

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -21,11 +21,11 @@ class S3PagedIter(PagedIter):
             *,
             prefix: str=None,
             delimiter: str=None,
-            marker: str=None,
+            start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
     ) -> None:
-        self.marker = marker
+        self.start_after_key = start_after_key
         self.token = token
 
         self.kwargs = dict()  # type: dict
@@ -107,7 +107,7 @@ class S3BlobStore(BlobStore):
             bucket: str,
             prefix: str=None,
             delimiter: str=None,
-            marker: str=None,
+            start_after_key: str=None,
             token: str=None,
             k_page_max: int=None
     ):  # type typing.Iterable[str]:
@@ -115,7 +115,7 @@ class S3BlobStore(BlobStore):
             bucket,
             prefix=prefix,
             delimiter=delimiter,
-            marker=marker,
+            start_after_key=start_after_key,
             token=token,
             k_page_max=k_page_max
         )

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -52,12 +52,11 @@ class BlobStoreTests:
         """
         Ensure that the ```list``` method returns sane data.
         """
-        items = [item for item in
-                 self.handle.list(
-                     self.test_fixtures_bucket,
-                     "test_good_source_data/0",
-                 )]
-        self.assertTrue(len(items) > 0)
+        items = list(self.handle.list(
+            self.test_fixtures_bucket,
+            "test_good_source_data/0",
+        ))
+        self.assertIn("test_good_source_data/0", items)
         for item in items:
             if item == "test_good_source_data/0":
                 break
@@ -65,40 +64,36 @@ class BlobStoreTests:
             self.fail("did not find the requisite key")
 
         # fetch a bunch of items all at once.
-        items = [item for item in
-                 self.handle.list(
-                     self.test_fixtures_bucket,
-                     "testList/prefix",
-                 )]
+        items = list(self.handle.list(
+            self.test_fixtures_bucket,
+            "testList/prefix",
+        ))
         self.assertEqual(len(items), 10)
 
         # this should fetch both testList/delimiter and testList/delimiter/test
-        items = [item for item in
-                 self.handle.list(
-                     self.test_fixtures_bucket,
-                     "testList/delimiter",
-                 )]
+        items = list(self.handle.list(
+            self.test_fixtures_bucket,
+            "testList/delimiter",
+        ))
         self.assertEqual(len(items), 2)
 
         # this should fetch only testList/delimiter
-        items = [item for item in
-                 self.handle.list(
-                     self.test_fixtures_bucket,
-                     "testList/delimiter",
-                     delimiter="/"
-                 )]
+        items = list(self.handle.list(
+            self.test_fixtures_bucket,
+            "testList/delimiter",
+            delimiter="/"
+        ))
         self.assertEqual(len(items), 1)
 
     def testListV2(self):
         """
-        Ensure that the ```list``` method returns sane data.
+        Ensure that the ```list_v2``` method returns sane data.
         """
-        items = [item for item in
-                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     "test_good_source_data/0",
-                 )]
-        self.assertTrue(len(items) > 0)
+        items = list(self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "test_good_source_data/0",
+        ))
+        self.assertIn("test_good_source_data/0", items)
         for item in items:
             if item == "test_good_source_data/0":
                 break
@@ -106,37 +101,33 @@ class BlobStoreTests:
             self.fail("did not find the requisite key")
 
         # fetch a bunch of items all at once.
-        items = [item for item in
-                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     "testList/prefix",
-                 )]
+        items = list(self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/prefix",
+        ))
         self.assertEqual(len(items), 10)
 
         # fetch a bunch of items all at once with small page size
-        items = [item for item in
-                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     "testList/prefix",
-                    k_page_max=3
-                 )]
+        items = list(self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/prefix",
+            k_page_max=3
+        ))
         self.assertEqual(len(items), 10)
 
         # this should fetch both testList/delimiter and testList/delimiter/test
-        items = [item for item in
-                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     "testList/delimiter",
-                 )]
+        items = list(self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/delimiter",
+        ))
         self.assertEqual(len(items), 2)
 
         # this should fetch only testList/delimiter
-        items = [item for item in
-                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     "testList/delimiter",
-                     delimiter="/"
-                 )]
+        items = list(self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/delimiter",
+            delimiter="/"
+        ))
         self.assertEqual(len(items), 1)
 
     def testListV2Continuation(self):
@@ -148,7 +139,7 @@ class BlobStoreTests:
             self.test_fixtures_bucket,
             "testList/prefix",
             k_page_max=page_size,
-        ) 
+        )
 
         items1 = list()
         items2 = list()
@@ -163,8 +154,8 @@ class BlobStoreTests:
         blobiter = self.handle.list_v2(
             self.test_fixtures_bucket,
             "testList/prefix",
-            token = blobiter.token,
-            marker = items1[-1],
+            token=blobiter.token,
+            marker=items1[-1],
             k_page_max=page_size,
         )
 
@@ -176,9 +167,9 @@ class BlobStoreTests:
         with self.assertRaises(BlobPagingError):
             [item for item in
                 self.handle.list_v2(
-                     self.test_fixtures_bucket,
-                     marker="nonsensicalnonsene"
-                 )]
+                    self.test_fixtures_bucket,
+                    marker="nonsensicalnonsene"
+                )]
 
     def testGetPresignedUrl(self):
         presigned_url = self.handle.generate_presigned_GET_url(

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -155,7 +155,7 @@ class BlobStoreTests:
             self.test_fixtures_bucket,
             "testList/prefix",
             token=blobiter.token,
-            marker=items1[-1],
+            start_after_key=items1[-1],
             k_page_max=page_size,
         )
 
@@ -163,12 +163,12 @@ class BlobStoreTests:
 
         self.assertEqual(len(items1) + len(items2), 10)
 
-        # starting from an unfound marker should raise an error
+        # starting from an unfound start_after_key should raise an error
         with self.assertRaises(BlobPagingError):
             [item for item in
                 self.handle.list_v2(
                     self.test_fixtures_bucket,
-                    marker="nonsensicalnonsene"
+                    start_after_key="nonsensicalnonsene"
                 )]
 
     def testGetPresignedUrl(self):

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -2,7 +2,7 @@ import io
 
 import requests
 
-from cloud_blobstore import BlobNotFoundError, BlobStore
+from cloud_blobstore import BlobNotFoundError, BlobStore, BlobPagingError
 from tests import infra
 
 
@@ -88,6 +88,97 @@ class BlobStoreTests:
                      delimiter="/"
                  )]
         self.assertEqual(len(items), 1)
+
+    def testListV2(self):
+        """
+        Ensure that the ```list``` method returns sane data.
+        """
+        items = [item for item in
+                 self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     "test_good_source_data/0",
+                 )]
+        self.assertTrue(len(items) > 0)
+        for item in items:
+            if item == "test_good_source_data/0":
+                break
+        else:
+            self.fail("did not find the requisite key")
+
+        # fetch a bunch of items all at once.
+        items = [item for item in
+                 self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     "testList/prefix",
+                 )]
+        self.assertEqual(len(items), 10)
+
+        # fetch a bunch of items all at once with small page size
+        items = [item for item in
+                 self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     "testList/prefix",
+                    k_page_max=3
+                 )]
+        self.assertEqual(len(items), 10)
+
+        # this should fetch both testList/delimiter and testList/delimiter/test
+        items = [item for item in
+                 self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     "testList/delimiter",
+                 )]
+        self.assertEqual(len(items), 2)
+
+        # this should fetch only testList/delimiter
+        items = [item for item in
+                 self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     "testList/delimiter",
+                     delimiter="/"
+                 )]
+        self.assertEqual(len(items), 1)
+
+    def testListV2Continuation(self):
+        self._testListV2Continuation(2, 3)
+        self._testListV2Continuation(2, 4)
+
+    def _testListV2Continuation(self, page_size, break_size):
+        blobiter = self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/prefix",
+            k_page_max=page_size,
+        ) 
+
+        items1 = list()
+        items2 = list()
+
+        for i, item in enumerate(blobiter):
+            items1.append(
+                item
+            )
+            if i >= break_size - 1:
+                break
+
+        blobiter = self.handle.list_v2(
+            self.test_fixtures_bucket,
+            "testList/prefix",
+            token = blobiter.token,
+            marker = items1[-1],
+            k_page_max=page_size,
+        )
+
+        items2 = [item for item in blobiter]
+
+        self.assertEqual(len(items1) + len(items2), 10)
+
+        # starting from an unfound marker should raise an error
+        with self.assertRaises(BlobPagingError):
+            [item for item in
+                self.handle.list_v2(
+                     self.test_fixtures_bucket,
+                     marker="nonsensicalnonsene"
+                 )]
 
     def testGetPresignedUrl(self):
         presigned_url = self.handle.generate_presigned_GET_url(


### PR DESCRIPTION
- Provide a blobstore iterator over blob keys that can be continued using an opaque page token and marker (blob key).
- Token handing is backgrounded unless explicit continuation is needed.
- Iterator will visit every key (as filtered by prefix/delimiter).