### PR TITLE
Add check_bucket_exists function

### DIFF
--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -241,3 +241,12 @@ class GSBlobStore(BlobStore):
         src_blob_obj = src_bucket_obj.get_blob(src_key)
         dst_bucket_obj = self._ensure_bucket_loaded(dst_bucket)
         src_bucket_obj.copy_blob(src_blob_obj, dst_bucket_obj, new_name=dst_key)
+
+    def check_bucket_exists(self, bucket: str) -> bool:
+        """
+        Checks if bucket with specified name exists.
+        :param bucket: the bucket to be checked.
+        :return: true if specified bucket exists.
+        """
+        bucket_obj = self.gcp_client.bucket(bucket)  # type: Bucket
+        return bucket_obj.exists()

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -262,3 +262,12 @@ class BlobStoreTests:
         with self.assertRaises(BlobNotFoundError):
             self.handle.get_user_metadata(
                 self.test_bucket, dst_blob_name)
+
+    def test_check_bucket_exists(self):
+        """
+        Ensure that the ``check_bucket_exists`` method returns true for FIXTURE AND TEST buckets.
+        """
+        handle = self.handle  # type: BlobStore
+        self.assertEqual(handle.check_bucket_exists(self.test_fixtures_bucket), True)
+        self.assertEqual(handle.check_bucket_exists(self.test_bucket), True)
+        self.assertEqual(handle.check_bucket_exists('e47114c9-bb96-480f-b6f5-c3e07aae399f'), False)

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -39,15 +39,5 @@ class TestGSBlobStore(unittest.TestCase, BlobStoreTests):
                 self.test_fixtures_bucket,
                 "test_good_source_data_DOES_NOT_EXIST")
 
-    def test_check_bucket_exists(self):
-        """
-        Ensure that the ``check_bucket_exists`` method returns true for FIXTURE AND TEST buckets.
-        """
-        handle = self.handle  # type: BlobStore
-        self.assertEqual(handle.check_bucket_exists(self.test_fixtures_bucket), True)
-        self.assertEqual(handle.check_bucket_exists(self.test_bucket), True)
-        self.assertEqual(handle.check_bucket_exists('e47114c9-bb96-480f-b6f5-c3e07aae399f'), False)
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -39,5 +39,15 @@ class TestGSBlobStore(unittest.TestCase, BlobStoreTests):
                 self.test_fixtures_bucket,
                 "test_good_source_data_DOES_NOT_EXIST")
 
+    def test_check_bucket_exists(self):
+        """
+        Ensure that the ``check_bucket_exists`` method returns true for FIXTURE AND TEST buckets.
+        """
+        handle = self.handle  # type: BlobStore
+        self.assertEqual(handle.check_bucket_exists(self.test_fixtures_bucket), True)
+        self.assertEqual(handle.check_bucket_exists(self.test_bucket), True)
+        self.assertEqual(handle.check_bucket_exists('e47114c9-bb96-480f-b6f5-c3e07aae399f'), False)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -137,15 +137,6 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
             else:
                 self.assertIn(ix, res)
 
-    def test_check_bucket_exists(self):
-        """
-        Ensure that the ``check_bucket_exists`` method returns true for FIXTURE AND TEST buckets.
-        """
-        handle = self.handle  # type: BlobStore
-        self.assertEqual(handle.check_bucket_exists(self.test_fixtures_bucket), True)
-        self.assertEqual(handle.check_bucket_exists(self.test_bucket), True)
-        self.assertEqual(handle.check_bucket_exists('e47114c9-bb96-480f-b6f5-c3e07aae399f'), False)
-
     def test_get_bucket_region(self):
         """
         Ensure that the ``get_bucket_region`` method returns true for FIXTURE and TEST buckets.


### PR DESCRIPTION
Add GCP version of the check_bucket_exists function.
The function is to be initially used by the HCA DSS checkout service.

Add a new unit test - positive and negative test of a bucket existence 
