### PR TITLE
Introduce the notion of a copy precondition token.

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -168,6 +168,23 @@ class BlobStore:
         """
         raise NotImplementedError()
 
+    def get_copy_token(
+            self,
+            bucket: str,
+            key: str,
+            cloud_checksum: str,
+    ) -> typing.Any:
+        """
+        Given a bucket, key, and the expected cloud-provided checksum, retrieve a token that can be passed into
+        :func:`~cloud_blobstore.BlobStore.copy` that guarantees the copy refers to the same version of the blob
+        identified by the checksum.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which checksum is being retrieved.
+        :param cloud_checksum: the expected cloud-provided checksum.
+        :return: an opaque copy token
+        """
+        raise NotImplementedError()
+
     def get_user_metadata(
             self,
             bucket: str,
@@ -200,6 +217,7 @@ class BlobStore:
             self,
             src_bucket: str, src_key: str,
             dst_bucket: str, dst_key: str,
+            copy_token: typing.Any=None,
             **kwargs):
         raise NotImplementedError()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3
-google-cloud-storage
+google-cloud-storage >= 1.7.0
 requests


### PR DESCRIPTION
It's an opaque token that, when retrieved, can stop a copy if the key is overwritten with different data than we expect.  Given a bucket/key/checksum, a token is provided that can be passed to `copy(..)` and inhibits the copy if the token does not match what we're expecting.

On S3, it's just etag + CopySourceIfMatch.  On GS, it's generation id.