### PR TITLE
Handle connection timeouts with BlobStoreReadError

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -249,6 +249,10 @@ class BlobStoreCredentialError(BlobStoreError):
     pass
 
 
+class BlobStoreReadError(BlobStoreError):
+    pass
+
+
 class BlobBucketNotFoundError(BlobStoreError):
     pass
 

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -4,11 +4,13 @@ import requests
 import typing
 
 from boto3.s3.transfer import TransferConfig
+from botocore.vendored.requests.exceptions import ReadTimeout
 
 from . import (
     BlobNotFoundError,
     BlobStore,
     BlobStoreCredentialError,
+    BlobStoreReadError,
     BlobStoreUnknownError,
     PagedIter,
 )
@@ -162,12 +164,15 @@ class S3BlobStore(BlobStore):
             extra_args['ContentType'] = content_type
         if metadata is not None:
             extra_args['Metadata'] = metadata
-        self.s3_client.upload_fileobj(
-            src_file_handle,
-            Bucket=bucket,
-            Key=key,
-            ExtraArgs=extra_args
-        )
+        try:
+            self.s3_client.upload_fileobj(
+                src_file_handle,
+                Bucket=bucket,
+                Key=key,
+                ExtraArgs=extra_args
+            )
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def delete(self, bucket: str, key: str):
         self.s3_client.delete_object(
@@ -193,6 +198,8 @@ class S3BlobStore(BlobStore):
             if ex.response['Error']['Code'] == "NoSuchKey":
                 raise BlobNotFoundError(ex)
             raise BlobStoreUnknownError(ex)
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def get_all_metadata(
             self,
@@ -215,6 +222,8 @@ class S3BlobStore(BlobStore):
                     str(requests.codes.not_found):
                 raise BlobNotFoundError(ex)
             raise BlobStoreUnknownError(ex)
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def get_content_type(
             self,
@@ -294,6 +303,8 @@ class S3BlobStore(BlobStore):
                     str(requests.codes.not_found):
                 raise BlobNotFoundError(ex)
             raise BlobStoreUnknownError(ex)
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def copy(
             self,
@@ -321,6 +332,8 @@ class S3BlobStore(BlobStore):
         except botocore.exceptions.ClientError as ex:
             if str(ex.response['Error']['Code']) == str(requests.codes.precondition_failed):
                 raise BlobNotFoundError(ex)
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def get_size(
             self,
@@ -341,6 +354,8 @@ class S3BlobStore(BlobStore):
             if str(ex.response['Error']['Code']) == str(requests.codes.not_found):
                 raise BlobNotFoundError(ex)
             raise BlobStoreUnknownError(ex)
+        except ReadTimeout as ex:
+            raise BlobStoreReadError(ex)
 
     def find_next_missing_parts(
             self,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ flake8
 mypy
 setuptools
 wheel
+mock
 -r requirements.txt

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -150,6 +150,9 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
         self.assertNotEqual(handle.get_bucket_region(self.test_non_us_east_1_bucket), 'us-east-1')
 
     def test_raises_read_error(self):
+        """
+        Ensure that we handle botocore ReadTimeouts
+        """
         def fake_connect():
             raise SocketTimeout('Bummer')
         with mock.patch(


### PR DESCRIPTION
Wrap low-level boto timeout errors into `BlobStoreReadError`.

The idea is to mitigate against the long tail of s3. Backend services may use boto's timeout configurations to give up in a controlled fashion.