### PR TITLE
Handle connection timeouts with BlobStoreTimeoutError

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -249,6 +249,16 @@ class BlobStoreCredentialError(BlobStoreError):
     pass
 
 
+class BlobStoreTimeoutError(BlobStoreError):
+    """
+    BlobStoreTimeoutError wraps timeout erros from boto3, which arrise during difficulty when making
+    a connection (ConnectTimeout), or during slow reads (ReadTimeout). These may be controlled in
+    the `botocore.Config` arguments `read_timeout` and `connect_timeout`, and are influinced
+    by boto retry configurations.
+    """
+    pass
+
+
 class BlobBucketNotFoundError(BlobStoreError):
     pass
 

--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -251,10 +251,9 @@ class BlobStoreCredentialError(BlobStoreError):
 
 class BlobStoreTimeoutError(BlobStoreError):
     """
-    BlobStoreTimeoutError wraps timeout erros from boto3, which arrise during difficulty when making
-    a connection (ConnectTimeout), or during slow reads (ReadTimeout). These may be controlled in
-    the `botocore.Config` arguments `read_timeout` and `connect_timeout`, and are influinced
-    by boto retry configurations.
+    BlobStoreTimeoutError wraps timeout errors from cloud providers.
+    For instance, boto3 provides `read_timeout` and `connect_timeout` configurations that may
+    lead to `ConnectTimeout` and `ReadTimeout` exceeptions.
     """
     pass
 

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -17,6 +17,15 @@ from . import (
 )
 
 
+def CatchTimeouts(meth):
+    def wrapped(*args, **kwargs):
+        try:
+            return meth(*args, **kwargs)
+        except (ConnectTimeout, ReadTimeout) as ex:
+            raise BlobStoreTimeoutError(ex)
+    return wrapped
+
+
 class S3PagedIter(PagedIter):
     def __init__(
             self,
@@ -423,11 +432,3 @@ class S3BlobStore(BlobStore):
         """
         region = self.s3_client.get_bucket_location(Bucket=bucket)["LocationConstraint"]
         return 'us-east-1' if region is None else region
-
-
-def CatchTimeouts(meth):
-    def wrapped(*args, **kwargs):
-        try:
-            meth(*args, **kwargs)
-        except (ConnectTimeout, ReadTimeout) as ex:
-            raise BlobStoreTimeoutError(ex)

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -14,6 +14,7 @@ import contextlib
 import socket
 from multiprocessing import Process, Manager
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
 from botocore.vendored.requests.exceptions import ReadTimeout
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -152,28 +153,28 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
         Ensure that the ``get_bucket_region`` method returns true for FIXTURE and TEST buckets.
         """
         handle = self.handle  # type: BlobStore
-        self.assertEqual(handle.get_bucket_region(self.test_us_east_1_bucket), 'us-east-1')
-        self.assertNotEqual(handle.get_bucket_region(self.test_non_us_east_1_bucket), 'us-east-1')
+        self.assertEqual(handle.get_bucket_region(self.test_us_east_1_bucket), "us-east-1")
+        self.assertNotEqual(handle.get_bucket_region(self.test_non_us_east_1_bucket), "us-east-1")
 
     def test_read_timeout(self):
         read_timeout = 1
         with contextlib.closing(ProxyConnectServer.start(2 * read_timeout)):
             config = botocore.config.Config(
                 proxies={
-                    'http': f'{ProxyConnectServer.address}:{ProxyConnectServer.shared_info["port"]}',
-                    'https': f'{ProxyConnectServer.address}:{ProxyConnectServer.shared_info["port"]}',
+                    'http': f"{ProxyConnectServer.address}:{ProxyConnectServer.shared_info['port']}",
+                    'https': f"{ProxyConnectServer.address}:{ProxyConnectServer.shared_info['port']}",
                 },
                 read_timeout=read_timeout,
                 retries={'max_attempts': 0}
             )
-            s3_client = boto3.client('s3', config=config)
+            s3_client = boto3.client("s3", config=config)
             handle = S3BlobStore(s3_client)
 
             # Make sure we actually raise a ReadError
             with self.assertRaises(ReadTimeout):
                 s3_client.put_object(
                     Bucket=self.test_bucket,
-                    Key='fake_key',
+                    Key="fake_key",
                     Body=os.urandom(1000)
                 )
 
@@ -181,7 +182,7 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
             with self.assertRaises(BlobStoreTimeoutError):
                 handle.upload_file_handle(
                     self.test_bucket,
-                    'fake_key',
+                    "fake_key",
                     io.BytesIO(os.urandom(1000))
                 )
 
@@ -190,24 +191,24 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
         Ensure that we handle botocore ConnectTimeouts
         """
         s3_client = boto3.client(
-            's3',
+            "s3",
             config=botocore.config.Config(
-                retries={'max_attempts': 0}
+                retries={"max_attempts": 0}
             )
         )
 
         # Point boto to an unresponsive host
         s3_client._endpoint = botocore.endpoint.Endpoint(
-            'https://www.chanzuckerberg.com:3000',
-            '',
+            "https://www.chanzuckerberg.com:3000",
+            "",
             s3_client._endpoint._event_emitter
         )
-        handle = S3BlobStore(s3_client)
 
+        handle = S3BlobStore(s3_client)
         with self.assertRaises(BlobStoreTimeoutError):
             handle.upload_file_handle(
                 self.test_bucket,
-                'fake_key',
+                "fake_key",
                 io.BytesIO(os.urandom(1000))
             )
 
@@ -218,7 +219,7 @@ def unused_tcp_port():
         return sock.getsockname()[1]
 
 class ProxyConnectServer(HTTPServer):
-    address = '127.0.0.1'
+    address = "127.0.0.1"
     process = None
     manager = None
     shared_info = None
@@ -229,7 +230,7 @@ class ProxyConnectServer(HTTPServer):
 
     def server_activate(self, *args, **kwargs):
         super().server_activate(*args, **kwargs)
-        ProxyConnectServer.shared_info['is_active'] = True
+        ProxyConnectServer.shared_info["is_active"] = True
 
     @classmethod
     def start(cls, read_delay=0):
@@ -242,10 +243,10 @@ class ProxyConnectServer(HTTPServer):
 
         class LazyRequestHandler(BaseHTTPRequestHandler):
             def do_CONNECT(self):
-                address = self.path.split(':', 1)
+                address = self.path.split(":", 1)
                 address[1] = int(address[1]) or 443
                 s = socket.create_connection(address, timeout=self.timeout)
-                self.send_response(200, 'Connection Established')
+                self.send_response(200, "Connection Established")
                 self.end_headers()
 
                 conns = [self.connection, s]
@@ -284,5 +285,5 @@ class ProxyConnectServer(HTTPServer):
         cls.manager = None
         cls.shared_info = None
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -193,7 +193,7 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
         s3_client = boto3.client(
             "s3",
             config=botocore.config.Config(
-                retries={"max_attempts": 0}
+                retries={'max_attempts': 0}
             )
         )
 
@@ -230,7 +230,7 @@ class ProxyConnectServer(HTTPServer):
 
     def server_activate(self, *args, **kwargs):
         super().server_activate(*args, **kwargs)
-        ProxyConnectServer.shared_info["is_active"] = True
+        ProxyConnectServer.shared_info['is_active'] = True
 
     @classmethod
     def start(cls, read_delay=0):

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import io
 import os
 import sys
+import time
 import unittest
 import uuid
+import select
+import boto3
+import botocore
+import contextlib
+import socket
+from multiprocessing import Process, Manager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from botocore.vendored.requests.exceptions import ReadTimeout
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from cloud_blobstore import BlobNotFoundError
+from cloud_blobstore import BlobNotFoundError, BlobStoreTimeoutError
 from cloud_blobstore.s3 import S3BlobStore
 from tests import infra
 from tests.blobstore_common_tests import BlobStoreTests
@@ -144,6 +154,135 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
         handle = self.handle  # type: BlobStore
         self.assertEqual(handle.get_bucket_region(self.test_us_east_1_bucket), 'us-east-1')
         self.assertNotEqual(handle.get_bucket_region(self.test_non_us_east_1_bucket), 'us-east-1')
+
+    def test_read_timeout(self):
+        read_timeout = 1
+        with contextlib.closing(ProxyConnectServer.start(2 * read_timeout)):
+            config = botocore.config.Config(
+                proxies={
+                    'http': f'{ProxyConnectServer.address}:{ProxyConnectServer.shared_info["port"]}',
+                    'https': f'{ProxyConnectServer.address}:{ProxyConnectServer.shared_info["port"]}',
+                },
+                read_timeout=read_timeout,
+                retries={'max_attempts': 0}
+            )
+            s3_client = boto3.client('s3', config=config)
+            handle = S3BlobStore(s3_client)
+
+            # Make sure we actually raise a ReadError
+            with self.assertRaises(ReadTimeout):
+                s3_client.put_object(
+                    Bucket=self.test_bucket,
+                    Key='fake_key',
+                    Body=os.urandom(1000)
+                )
+
+            # Make sure we correctly respond to a ReadError
+            with self.assertRaises(BlobStoreTimeoutError):
+                handle.upload_file_handle(
+                    self.test_bucket,
+                    'fake_key',
+                    io.BytesIO(os.urandom(1000))
+                )
+
+    def test_connect_timeout(self):
+        """
+        Ensure that we handle botocore ConnectTimeouts
+        """
+        s3_client = boto3.client(
+            's3',
+            config=botocore.config.Config(
+                retries={'max_attempts': 0}
+            )
+        )
+
+        # Point boto to an unresponsive host
+        s3_client._endpoint = botocore.endpoint.Endpoint(
+            'https://www.chanzuckerberg.com:3000',
+            '',
+            s3_client._endpoint._event_emitter
+        )
+        handle = S3BlobStore(s3_client)
+
+        with self.assertRaises(BlobStoreTimeoutError):
+            handle.upload_file_handle(
+                self.test_bucket,
+                'fake_key',
+                io.BytesIO(os.urandom(1000))
+            )
+
+
+def unused_tcp_port():
+    with contextlib.closing(socket.socket()) as sock:
+        sock.bind((ProxyConnectServer.address, 0))
+        return sock.getsockname()[1]
+
+class ProxyConnectServer(HTTPServer):
+    address = '127.0.0.1'
+    process = None
+    manager = None
+    shared_info = None
+
+    def __init__(self, *args, shared_info=None, **kwargs):
+        self.shared_info = shared_info
+        super().__init__(*args, **kwargs)
+
+    def server_activate(self, *args, **kwargs):
+        super().server_activate(*args, **kwargs)
+        ProxyConnectServer.shared_info['is_active'] = True
+
+    @classmethod
+    def start(cls, read_delay=0):
+        cls.manager = Manager()
+
+        shared_info = cls.manager.dict(
+            read_delay=read_delay
+        )
+        cls.shared_info = shared_info
+
+        class LazyRequestHandler(BaseHTTPRequestHandler):
+            def do_CONNECT(self):
+                address = self.path.split(':', 1)
+                address[1] = int(address[1]) or 443
+                s = socket.create_connection(address, timeout=self.timeout)
+                self.send_response(200, 'Connection Established')
+                self.end_headers()
+
+                conns = [self.connection, s]
+                self.close_connection = 0
+                while not self.close_connection:
+                    rlist, wlist, xlist = select.select(conns, [], conns, self.timeout)
+                    if xlist or not rlist:
+                        break
+                    for r in rlist:
+                        other = conns[1] if r is conns[0] else conns[0]
+                        data = r.recv(8192)
+                        if not data:
+                            self.close_connection = 1
+                            break
+                        time.sleep(shared_info['read_delay'])
+                        other.sendall(data)
+
+        def eternity():
+            port = unused_tcp_port()
+            shared_info['port'] = port
+            httpd = cls((cls.address, port), LazyRequestHandler, shared_info=shared_info)
+            httpd.serve_forever()
+
+        cls.process = Process(target=eternity)
+        cls.process.start()
+
+        while not shared_info.get('is_active', None):
+            time.sleep(0.25)
+
+        return cls
+
+    @classmethod
+    def close(cls):
+        cls.process.terminate()
+        cls.process = None
+        cls.manager = None
+        cls.shared_info = None
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Wrap low-level boto timeout errors into BlobStoreTimeoutError.

The idea is to mitigate against the long tail of s3. Backend services may use boto's timeout configurations to give up in a controlled fashion.