### PR TITLE
Expose last modified and other metadata fields on blobs

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import typing
 import types
 
@@ -182,6 +183,19 @@ class BlobStore:
         :param key: the key of the object for which checksum is being retrieved.
         :param cloud_checksum: the expected cloud-provided checksum.
         :return: an opaque copy token
+        """
+        raise NotImplementedError()
+
+    def get_last_modified_date(
+            self,
+            bucket: str,
+            key: str,
+    ) -> datetime:
+        """
+        Retrieves last modified date for a given key in a given bucket.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which the last modified date is being retrieved.
+        :return: the last modified date
         """
         raise NotImplementedError()
 

--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -1,9 +1,24 @@
 from datetime import datetime
+from enum import Enum
 import typing
 import types
 
 
-class PagedIter(typing.Iterable[str]):
+class BlobMetadataField(Enum):
+    """
+    Cloud-agnostic dictionary keys to represent blob metadata.
+
+    CHECKSUM      -  Checksum of the blob.
+                     Values returned are cloud-specific and should not be compared across cloud providers.
+    LAST_MODIFIED -  Last modified date of the blob.
+    SIZE          -  Size of the blob.
+    """
+    CHECKSUM = "checksum"
+    LAST_MODIFIED = "last_modified"
+    SIZE = "size"
+
+
+class PagedIter(typing.Iterable[typing.Tuple[str, dict]]):
     """
     Provide an iterator that will iterate over every object, filtered by prefix and delimiter. Alternately continue
     iteration with token and key (start_after_key).
@@ -15,9 +30,11 @@ class PagedIter(typing.Iterable[str]):
         """
         raise NotImplementedError()
 
-    def get_listing_from_response(self, resp) -> typing.Iterable[str]:
+    def get_listing_from_response(self, resp) -> typing.Iterable[typing.Tuple[str, dict]]:
         """
-        Retrieve blob key listing from blobstore response.
+        Retrieve blob metadata objects from blobstore response.
+        Metadata objects represented as tuples in the form of:
+        (key, {BlobMetadataField: val, ...})
         """
         raise NotImplementedError()
 
@@ -46,11 +63,10 @@ class PagedIter(typing.Iterable[str]):
             if self.start_after_key:
                 while True:
                     try:
-                        key = next(listing)
+                        item = next(listing)
                     except StopIteration:
                         raise BlobPagingError('Marker not found in this page')
-
-                    if key == self.start_after_key:
+                    if item[0] == self.start_after_key:
                         break
 
             while True:
@@ -92,8 +108,8 @@ class BlobStore:
             delimiter: str=None,
             start_after_key: str=None,
             token: str=None,
-            k_page_max: int=None
-    ) -> typing.Iterable[str]:
+            k_page_max: int=None,
+    ) -> typing.Iterable[typing.Tuple[str, dict]]:
         """
         Returns an iterator of all blob entries in a bucket that match a given prefix.  Do not return any keys that
         contain the delimiter past the prefix.

--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from enum import Enum
 import typing
-import types
 
 
 class BlobMetadataField(Enum):

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -234,6 +234,21 @@ class GSBlobStore(BlobStore):
         return blob_obj.generation
 
     @CatchTimeouts
+    def get_last_modified_date(
+            self,
+            bucket: str,
+            key: str,
+    ) -> datetime.datetime:
+        """
+        Retrieves last modified date for a given key in a given bucket.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which the last modified date is being retrieved.
+        :return: the last modified date
+        """
+        blob_obj = self._get_blob_obj(bucket, key)
+        return blob_obj.updated
+
+    @CatchTimeouts
     def get_user_metadata(
             self,
             bucket: str,

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -168,11 +168,11 @@ class GSBlobStore(BlobStore):
         Deletes an object in a bucket.  If the operation definitely did not delete anything, return False.  Any other
         return value is treated as something was possibly deleted.
         """
+        bucket_obj = self._ensure_bucket_loaded(bucket)
         try:
-            blob_obj = self._get_blob_obj(bucket, key)
-        except BlobNotFoundError:
+            bucket_obj.delete_blob(key)
+        except NotFound:
             return False
-        blob_obj.delete()
 
     @CatchTimeouts
     def get(self, bucket: str, key: str) -> bytes:

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -1,5 +1,6 @@
 import boto3
 import botocore
+from datetime import datetime
 import requests
 import typing
 
@@ -278,6 +279,21 @@ class S3BlobStore(BlobStore):
         response = self.get_all_metadata(bucket, key)
         # hilariously, the ETag is quoted.  Unclear why.
         return response['ETag'].strip("\"")
+
+    @CatchTimeouts
+    def get_last_modified_date(
+            self,
+            bucket: str,
+            key: str,
+    ) -> datetime:
+        """
+        Retrieves last modified date for a given key in a given bucket.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which the last modified date is being retrieved.
+        :return: the last modified date
+        """
+        blob_obj = self.get_all_metadata(bucket, key)
+        return blob_obj['LastModified']
 
     @CatchTimeouts
     def get_user_metadata(

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -9,6 +9,7 @@ from boto3.s3.transfer import TransferConfig
 from botocore.vendored.requests.exceptions import ConnectTimeout, ReadTimeout
 
 from . import (
+    BlobMetadataField,
     BlobNotFoundError,
     BlobStore,
     BlobStoreCredentialError,
@@ -36,7 +37,7 @@ class S3PagedIter(PagedIter):
             delimiter: str=None,
             start_after_key: str=None,
             token: str=None,
-            k_page_max: int=None
+            k_page_max: int=None,
     ) -> None:
         self.start_after_key = start_after_key
         self.token = token
@@ -71,7 +72,11 @@ class S3PagedIter(PagedIter):
         else:
             contents = list()
 
-        return (b['Key'] for b in contents)
+        return ((b['Key'], {
+            BlobMetadataField.CHECKSUM: S3BlobStore.compute_cloud_checksum(b),
+            BlobMetadataField.LAST_MODIFIED: b['LastModified'],
+            BlobMetadataField.SIZE: b['Size'],
+        }) for b in contents)
 
     def get_next_token_from_response(self, resp):
         if resp['IsTruncated']:
@@ -87,6 +92,11 @@ class S3BlobStore(BlobStore):
         super(S3BlobStore, self).__init__()
 
         self.s3_client = s3_client
+
+    @staticmethod
+    def compute_cloud_checksum(metadata):
+        # hilariously, the ETag is quoted. Unclear why.
+        return metadata['ETag'].strip("\"")
 
     @classmethod
     def from_environment(cls):
@@ -128,15 +138,15 @@ class S3BlobStore(BlobStore):
             delimiter: str=None,
             start_after_key: str=None,
             token: str=None,
-            k_page_max: int=None
-    ) -> typing.Iterable[str]:
+            k_page_max: int=None,
+    ) -> typing.Iterable[typing.Tuple[str, dict]]:
         return S3PagedIter(
             bucket,
             prefix=prefix,
             delimiter=delimiter,
             start_after_key=start_after_key,
             token=token,
-            k_page_max=k_page_max
+            k_page_max=k_page_max,
         )
 
     def generate_presigned_GET_url(
@@ -277,8 +287,7 @@ class S3BlobStore(BlobStore):
         :return: the cloud-provided checksum
         """
         response = self.get_all_metadata(bucket, key)
-        # hilariously, the ETag is quoted.  Unclear why.
-        return response['ETag'].strip("\"")
+        return self.compute_cloud_checksum(response)
 
     @CatchTimeouts
     def get_last_modified_date(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="cloud-blobstore",
-    version="2.1.5",
+    version="3.0.0",
     url='https://github.com/chanzuckerberg/cloud-blobstore',
     license='Apache Software License',
     author='Human Cell Atlas contributors',

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -1,5 +1,5 @@
+from datetime import date
 import io
-
 import requests
 
 from cloud_blobstore import BlobNotFoundError, BlobStore, BlobPagingError
@@ -45,6 +45,17 @@ class BlobStoreTests:
 
         with self.assertRaises(BlobNotFoundError):
             handle.get_content_type(
+                self.test_fixtures_bucket,
+                "test_good_source_data_DOES_NOT_EXIST")
+
+    def test_get_last_modified_date(self):
+        last_modified = self.handle.get_last_modified_date(
+            self.test_fixtures_bucket,
+            "test_good_source_data/0")
+        self.assertTrue(isinstance(last_modified, date))
+
+        with self.assertRaises(BlobNotFoundError):
+            self.handle.get_last_modified_date(
                 self.test_fixtures_bucket,
                 "test_good_source_data_DOES_NOT_EXIST")
 

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -1,8 +1,8 @@
-from datetime import date
+from datetime import datetime
 import io
 import requests
 
-from cloud_blobstore import BlobNotFoundError, BlobStore, BlobPagingError
+from cloud_blobstore import BlobMetadataField, BlobNotFoundError, BlobStore, BlobPagingError
 from tests import infra
 
 
@@ -52,7 +52,7 @@ class BlobStoreTests:
         last_modified = self.handle.get_last_modified_date(
             self.test_fixtures_bucket,
             "test_good_source_data/0")
-        self.assertTrue(isinstance(last_modified, date))
+        self.assertTrue(isinstance(last_modified, datetime))
 
         with self.assertRaises(BlobNotFoundError):
             self.handle.get_last_modified_date(
@@ -100,16 +100,11 @@ class BlobStoreTests:
         """
         Ensure that the ```list_v2``` method returns sane data.
         """
-        items = list(self.handle.list_v2(
+        keys = list((key for key, item in self.handle.list_v2(
             self.test_fixtures_bucket,
             "test_good_source_data/0",
-        ))
-        self.assertIn("test_good_source_data/0", items)
-        for item in items:
-            if item == "test_good_source_data/0":
-                break
-        else:
-            self.fail("did not find the requisite key")
+        )))
+        self.assertIn("test_good_source_data/0", keys)
 
         # fetch a bunch of items all at once.
         items = list(self.handle.list_v2(
@@ -117,6 +112,10 @@ class BlobStoreTests:
             "testList/prefix",
         ))
         self.assertEqual(len(items), 10)
+        for ix, (key, metadata) in enumerate(items):
+            self.assertTrue(f"prefix.00{ix}" in key)
+            self.assertTrue(all(field in metadata for field in BlobMetadataField))
+            self.assertTrue(all(key in BlobMetadataField for key in metadata))
 
         # fetch a bunch of items all at once with small page size
         items = list(self.handle.list_v2(
@@ -155,11 +154,11 @@ class BlobStoreTests:
         items1 = list()
         items2 = list()
 
-        for i, item in enumerate(blobiter):
+        for ix, (key, item) in enumerate(blobiter):
             items1.append(
-                item
+                key
             )
-            if i >= break_size - 1:
+            if ix >= break_size - 1:
                 break
 
         blobiter = self.handle.list_v2(

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -67,6 +67,21 @@ class TestGSBlobStore(unittest.TestCase, BlobStoreTests):
                 io.BytesIO(os.urandom(1000))
             )
 
+    def test_get_blob_obj(self):
+        metadata = self.handle._get_blob_obj(self.test_fixtures_bucket,
+                                             "test_good_source_data/0")
+        self.assertTrue(hasattr(metadata, 'path'))
+        self.assertTrue(hasattr(metadata, 'crc32c'))
+        self.assertTrue(hasattr(metadata, 'content_type'))
+        self.assertTrue(hasattr(metadata, 'etag'))
+        self.assertTrue(hasattr(metadata, 'path'))
+        self.assertTrue(hasattr(metadata, 'size'))
+        self.assertTrue(hasattr(metadata, 'updated'))
+
+        with self.assertRaises(BlobNotFoundError):
+            self.handle._get_blob_obj(self.test_fixtures_bucket,
+                                      "test_good_source_data_DOES_NOT_EXIST")
+
     def _get_handle_with_timeouts(self, connect_timeout=60, read_timeout=60):
         class Session(google.auth.transport.requests.AuthorizedSession):
             def request(self, *args, **kwargs):

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -4,7 +4,6 @@
 import io
 import os
 import sys
-import json
 import unittest
 
 import google.auth.transport.requests

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -68,16 +68,6 @@ class TestGSBlobStore(unittest.TestCase, BlobStoreTests):
             )
 
     def test_get_blob_obj(self):
-        metadata = self.handle._get_blob_obj(self.test_fixtures_bucket,
-                                             "test_good_source_data/0")
-        self.assertTrue(hasattr(metadata, 'path'))
-        self.assertTrue(hasattr(metadata, 'crc32c'))
-        self.assertTrue(hasattr(metadata, 'content_type'))
-        self.assertTrue(hasattr(metadata, 'etag'))
-        self.assertTrue(hasattr(metadata, 'path'))
-        self.assertTrue(hasattr(metadata, 'size'))
-        self.assertTrue(hasattr(metadata, 'updated'))
-
         with self.assertRaises(BlobNotFoundError):
             self.handle._get_blob_obj(self.test_fixtures_bucket,
                                       "test_good_source_data_DOES_NOT_EXIST")
@@ -94,6 +84,7 @@ class TestGSBlobStore(unittest.TestCase, BlobStoreTests):
         )
 
         return GSBlobStore(Client(_http=Session(credentials)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
These changes:
- enable `list_v2` to return (key, blob) tuples (previously keys only) via `verbose` param
- add `get_last_modified_date` to retrieve a blob's last modified field given either: `bucket`, `key` or `blob`. The motivation to support the latter (previous support only for the former) is to minimize the number of network requests we make to retrieve a blob from a bucket, for example when processing a list of blobs retrieved via `list_v2`.

The new pattern introduced in point 2 is intended to provide the client with a single cloud-agnostic interface to read a blob's fields, without incurring unnecessary network requests. Currently, visibility into blobs is supported by field-specific functions that fetch a new blob object every time (e.g. `get_content_type`). `get_last_modified_date` is an example of a function that work directly with blob objects to achieve this.

EDIT:
`get_last_modified_date` only accepts `bucket` and `key` as parameters
`list_v2` only returns (key, blob) tuples (no verbose param)

Related to https://app.zenhub.com/workspace/o/humancellatlas/data-store/issues/1347