### PR TITLE
fix paged iter

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -70,8 +70,9 @@ class PagedIter(typing.Iterable[typing.Tuple[str, dict]]):
 
             while True:
                 try:
-                    self.start_after_key = next(listing)
-                    yield self.start_after_key
+                    item = next(listing)
+                    self.start_after_key = item[0]
+                    yield item
                 except StopIteration:
                     break
 

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -165,11 +165,13 @@ class BlobStoreTests:
             self.test_fixtures_bucket,
             "testList/prefix",
             token=blobiter.token,
-            start_after_key=items1[-1],
+            start_after_key=blobiter.start_after_key,
             k_page_max=page_size,
         )
 
-        items2 = [item for item in blobiter]
+        for blob in blobiter:
+            items2.append(blob)
+            self.assertEquals(blobiter.start_after_key, blob[0])
 
         self.assertEqual(len(items1) + len(items2), 10)
 


### PR DESCRIPTION
It doesn't look like the value of `start_after_key` matters at this point in the iteration, but just to be consistent. @xbrianh Any reason to keep the value of `start_after_key` updated here? Otherwise, we can just `yield next(listing)`.