### PR TITLE
Expose creation date on cloud objects

### DIFF
--- a/cloud_blobstore/__init__.py
+++ b/cloud_blobstore/__init__.py
@@ -13,6 +13,7 @@ class BlobMetadataField(Enum):
     SIZE          -  Size of the blob.
     """
     CHECKSUM = "checksum"
+    CREATED = "created"
     LAST_MODIFIED = "last_modified"
     SIZE = "size"
 
@@ -199,6 +200,19 @@ class BlobStore:
         :param key: the key of the object for which checksum is being retrieved.
         :param cloud_checksum: the expected cloud-provided checksum.
         :return: an opaque copy token
+        """
+        raise NotImplementedError()
+
+    def get_creation_date(
+            self,
+            bucket: str,
+            key: str,
+    ) -> datetime:
+        """
+        Retrieves the creation date for a given key in a given bucket.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which the creation date is being retrieved.
+        :return: the creation date
         """
         raise NotImplementedError()
 

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -60,6 +60,7 @@ class GSPagedIter(PagedIter):
     def get_listing_from_response(self, resp):
         return ((b.name, {
             BlobMetadataField.CHECKSUM: GSBlobStore.compute_cloud_checksum(b),
+            BlobMetadataField.CREATED: b.time_created,
             BlobMetadataField.LAST_MODIFIED: b.updated,
             BlobMetadataField.SIZE: b.size,
         }) for b in resp)
@@ -240,6 +241,21 @@ class GSBlobStore(BlobStore):
         blob_obj = self._get_blob_obj(bucket, key)
         assert binascii.hexlify(base64.b64decode(blob_obj.crc32c)).decode("utf-8").lower() == cloud_checksum
         return blob_obj.generation
+
+    @CatchTimeouts
+    def get_creation_date(
+            self,
+            bucket: str,
+            key: str,
+    ) -> datetime.datetime:
+        """
+        Retrieves the creation date for a given key in a given bucket.
+        :param bucket: the bucket the object resides in.
+        :param key: the key of the object for which the creation date is being retrieved.
+        :return: the creation date
+        """
+        blob_obj = self._get_blob_obj(bucket, key)
+        return blob_obj.time_created
 
     @CatchTimeouts
     def get_last_modified_date(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="cloud-blobstore",
-    version="3.0.0",
+    version="3.1.0",
     url='https://github.com/chanzuckerberg/cloud-blobstore',
     license='Apache Software License',
     author='Human Cell Atlas contributors',


### PR DESCRIPTION
Exposing creation date field on cloud objects.

For GS, this is available via the `time_created` field.
For S3, the creation date is also stored in the `LastModified` field.

I'm iffy about exposing a `creation_date` field given the S3 value will ambiguously return the actual creation date or the last modified, but that's also as accurate as S3 provides. 