### PR TITLE
Add multipart parallel upload support for s3

### DIFF
--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -419,7 +419,7 @@ class S3BlobStore(BlobStore):
         Upload a file object in parallel.
         :param bucket:
         """
-        kwargs = dict()
+        kwargs: dict = dict()
         if content_type is not None:
             kwargs['ContentType'] = content_type
         if metadata is not None:

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -410,6 +410,7 @@ class S3BlobStore(BlobStore):
             bucket: str,
             key: str,
             src_file_handle: typing.BinaryIO,
+            size: int,
             part_size: int,
             content_type: str=None,
             metadata: dict=None,
@@ -425,7 +426,6 @@ class S3BlobStore(BlobStore):
             kwargs['Metadata'] = metadata
         mpu = self.s3_client.create_multipart_upload(Bucket=bucket, Key=key, **kwargs)
 
-        size = src_file_handle.getbuffer().nbytes
         part_count = size // part_size
         if part_count * part_size < size:
             part_count += 1

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -228,6 +228,39 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
                 io.BytesIO(os.urandom(1000))
             )
 
+    def test_multipart_parallel_upload(self):
+        data = os.urandom(7 * 1024 * 1024)
+        metadata = {'something': "foolish"}
+        part_size = 5 * 1024 * 1024
+        with self.subTest("copy multiple parts"):
+            with io.BytesIO(data) as fh:
+                self.handle.multipart_parallel_upload(
+                    self.test_bucket,
+                    "fake_key",
+                    fh,
+                    part_size,
+                    metadata=metadata,
+                    content_type="application/octet-stream",
+                )
+        part_size = 14 * 1024 * 1024
+        with self.subTest("should work with single part"):
+            with io.BytesIO(data) as fh:
+                self.handle.multipart_parallel_upload(
+                    self.test_bucket,
+                    "fake_key",
+                    fh,
+                    part_size,
+                )
+        part_size = 5 * 1024 * 1024
+        with self.subTest("should work parallelization factor of 1"):
+            with io.BytesIO(data) as fh:
+                self.handle.multipart_parallel_upload(
+                    self.test_bucket,
+                    "fake_key",
+                    fh,
+                    part_size,
+                    parallelization_factor=1,
+                )
 
 def unused_tcp_port():
     with contextlib.closing(socket.socket()) as sock:

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -229,7 +229,8 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
             )
 
     def test_multipart_parallel_upload(self):
-        data = os.urandom(7 * 1024 * 1024)
+        size = 7 * 1024 * 1024
+        data = os.urandom(size)
         metadata = {'something': "foolish"}
         part_size = 5 * 1024 * 1024
         with self.subTest("copy multiple parts"):
@@ -238,6 +239,7 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
                     self.test_bucket,
                     "fake_key",
                     fh,
+                    size,
                     part_size,
                     metadata=metadata,
                     content_type="application/octet-stream",
@@ -249,6 +251,7 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
                     self.test_bucket,
                     "fake_key",
                     fh,
+                    size,
                     part_size,
                 )
         part_size = 5 * 1024 * 1024
@@ -258,6 +261,7 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
                     self.test_bucket,
                     "fake_key",
                     fh,
+                    size,
                     part_size,
                     parallelization_factor=1,
                 )


### PR DESCRIPTION
This is useful for optimizing [DSS](https://github.com/HumanCellAtlas/data-store) endpoints, and may have a wider audience.