### PR TITLE
Add response content disposition.

### DIFF
--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -2,7 +2,6 @@ import base64
 import binascii
 import datetime
 import typing
-import copy
 
 from google.cloud.exceptions import NotFound
 from google.cloud.storage import Client

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -145,13 +145,12 @@ class GSBlobStore(BlobStore):
             self,
             bucket: str,
             key: str,
+            response_content_disposition: str = None,
             **kwargs) -> str:
         blob_obj = self._get_blob_obj(bucket, key)
 
-        # if the aws ResponseContentDisposition keyword was used, sub in the google keyword
-        if 'ResponseContentDisposition' in kwargs:
-            kwargs['response_disposition'] = copy.deepcopy(kwargs['ResponseContentDisposition'])
-            del kwargs['ResponseContentDisposition']
+        if response_content_disposition:
+            kwargs['response_disposition'] = response_content_disposition
 
         return blob_obj.generate_signed_url(datetime.timedelta(days=1), **kwargs)
 

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import datetime
 import typing
+import copy
 
 from google.cloud.exceptions import NotFound
 from google.cloud.storage import Client
@@ -146,7 +147,10 @@ class GSBlobStore(BlobStore):
             key: str,
             **kwargs) -> str:
         blob_obj = self._get_blob_obj(bucket, key)
-        return blob_obj.generate_signed_url(datetime.timedelta(days=1))
+        if 'ResponseContentDisposition' in kwargs:
+            kwargs['response_disposition'] = copy.deepcopy(kwargs['ResponseContentDisposition'])
+            del kwargs['ResponseContentDisposition']
+        return blob_obj.generate_signed_url(datetime.timedelta(days=1), **kwargs)
 
     @CatchTimeouts
     def upload_file_handle(

--- a/cloud_blobstore/gs.py
+++ b/cloud_blobstore/gs.py
@@ -147,9 +147,12 @@ class GSBlobStore(BlobStore):
             key: str,
             **kwargs) -> str:
         blob_obj = self._get_blob_obj(bucket, key)
+
+        # if the aws ResponseContentDisposition keyword was used, sub in the google keyword
         if 'ResponseContentDisposition' in kwargs:
             kwargs['response_disposition'] = copy.deepcopy(kwargs['ResponseContentDisposition'])
             del kwargs['ResponseContentDisposition']
+
         return blob_obj.generate_signed_url(datetime.timedelta(days=1), **kwargs)
 
     @CatchTimeouts

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -3,7 +3,6 @@ import botocore
 from datetime import datetime
 import requests
 import typing
-import copy
 
 from boto3.s3.transfer import TransferConfig
 

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -156,12 +156,11 @@ class S3BlobStore(BlobStore):
             self,
             bucket: str,
             key: str,
+            response_content_disposition: str = None,
             **kwargs) -> str:
 
-        # if the google response_disposition keyword was used, sub in the aws keyword
-        if 'response_disposition' in kwargs:
-            kwargs['ResponseContentDisposition'] = copy.deepcopy(kwargs['response_disposition'])
-            del kwargs['response_disposition']
+        if response_content_disposition:
+            kwargs['ResponseContentDisposition'] = response_content_disposition
 
         return self._generate_presigned_url(
             bucket,

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -157,9 +157,12 @@ class S3BlobStore(BlobStore):
             bucket: str,
             key: str,
             **kwargs) -> str:
+
+        # if the google response_disposition keyword was used, sub in the aws keyword
         if 'response_disposition' in kwargs:
             kwargs['ResponseContentDisposition'] = copy.deepcopy(kwargs['response_disposition'])
             del kwargs['response_disposition']
+
         return self._generate_presigned_url(
             bucket,
             key,

--- a/cloud_blobstore/s3.py
+++ b/cloud_blobstore/s3.py
@@ -3,6 +3,7 @@ import botocore
 from datetime import datetime
 import requests
 import typing
+import copy
 
 from boto3.s3.transfer import TransferConfig
 
@@ -156,10 +157,14 @@ class S3BlobStore(BlobStore):
             bucket: str,
             key: str,
             **kwargs) -> str:
+        if 'response_disposition' in kwargs:
+            kwargs['ResponseContentDisposition'] = copy.deepcopy(kwargs['response_disposition'])
+            del kwargs['response_disposition']
         return self._generate_presigned_url(
             bucket,
             key,
-            "get_object"
+            "get_object",
+            **kwargs
         )
 
     def _generate_presigned_url(

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -246,7 +246,7 @@ class BlobStoreTests:
             presigned_url = self.handle.generate_presigned_GET_url(
                 self.test_fixtures_bucket,
                 "test_good_source_data/0",
-                response_disposition='attachment; filename=test-data.json')
+                response_content_disposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
             assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
 
@@ -254,7 +254,7 @@ class BlobStoreTests:
             presigned_url = self.handle.generate_presigned_GET_url(
                 self.test_fixtures_bucket,
                 "test_good_source_data/0",
-                ResponseContentDisposition='attachment; filename=test-data.json')
+                response_content_disposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
             assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
 

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -241,6 +241,23 @@ class BlobStoreTests:
         sz = self.handle.get_size(self.test_fixtures_bucket, "test_good_source_data/0")
         self.assertEqual(sz, 11358)
 
+    def testContentDisposition(self):
+        with self.subTest('Test Google Content-Disposition kwarg for presigned urls.'):
+            presigned_url = self.handle.generate_presigned_GET_url(
+                self.test_fixtures_bucket,
+                "test_good_source_data/0",
+                response_disposition='attachment; filename=test-data.json')
+            resp = requests.get(presigned_url)
+            assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+
+        with self.subTest('Test AWS Content-Disposition kwarg for presigned urls.'):
+            presigned_url = self.handle.generate_presigned_GET_url(
+                self.test_fixtures_bucket,
+                "test_good_source_data/0",
+                ResponseContentDisposition='attachment; filename=test-data.json')
+            resp = requests.get(presigned_url)
+            assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+
     def testCopy(self):
         dst_blob_name = infra.generate_test_key()
 

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -248,10 +248,7 @@ class BlobStoreTests:
                 "test_good_source_data/0",
                 response_disposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
-            print(resp)
-            print(resp.headers)
-            assert 'response-content-disposition' in resp.headers
-            # assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+            assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
 
         with self.subTest('Test AWS Content-Disposition kwarg for presigned urls.'):
             presigned_url = self.handle.generate_presigned_GET_url(
@@ -259,10 +256,7 @@ class BlobStoreTests:
                 "test_good_source_data/0",
                 ResponseContentDisposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
-            print(resp)
-            print(resp.headers)
-            assert 'response-content-disposition' in resp.headers
-            # assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+            assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
 
     def testCopy(self):
         dst_blob_name = infra.generate_test_key()

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -248,7 +248,10 @@ class BlobStoreTests:
                 "test_good_source_data/0",
                 response_disposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
-            assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+            print(resp)
+            print(resp.headers)
+            assert 'response-content-disposition' in resp.headers
+            # assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
 
         with self.subTest('Test AWS Content-Disposition kwarg for presigned urls.'):
             presigned_url = self.handle.generate_presigned_GET_url(
@@ -256,7 +259,10 @@ class BlobStoreTests:
                 "test_good_source_data/0",
                 ResponseContentDisposition='attachment; filename=test-data.json')
             resp = requests.get(presigned_url)
-            assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
+            print(resp)
+            print(resp.headers)
+            assert 'response-content-disposition' in resp.headers
+            # assert resp.headers['response-content-disposition'] == 'attachment; filename=test-data.json', resp.headers
 
     def testCopy(self):
         dst_blob_name = infra.generate_test_key()

--- a/tests/blobstore_common_tests.py
+++ b/tests/blobstore_common_tests.py
@@ -242,21 +242,12 @@ class BlobStoreTests:
         self.assertEqual(sz, 11358)
 
     def testContentDisposition(self):
-        with self.subTest('Test Google Content-Disposition kwarg for presigned urls.'):
-            presigned_url = self.handle.generate_presigned_GET_url(
-                self.test_fixtures_bucket,
-                "test_good_source_data/0",
-                response_content_disposition='attachment; filename=test-data.json')
-            resp = requests.get(presigned_url)
-            assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
-
-        with self.subTest('Test AWS Content-Disposition kwarg for presigned urls.'):
-            presigned_url = self.handle.generate_presigned_GET_url(
-                self.test_fixtures_bucket,
-                "test_good_source_data/0",
-                response_content_disposition='attachment; filename=test-data.json')
-            resp = requests.get(presigned_url)
-            assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
+        presigned_url = self.handle.generate_presigned_GET_url(
+            self.test_fixtures_bucket,
+            "test_good_source_data/0",
+            response_content_disposition='attachment; filename=test-data.json')
+        resp = requests.get(presigned_url)
+        assert resp.headers['Content-Disposition'] == 'attachment; filename=test-data.json', resp.headers
 
     def testCopy(self):
         dst_blob_name = infra.generate_test_key()


### PR DESCRIPTION
This allows generic `kwargs` to be passed through `generate_presigned_GET_url()` for both aws and gcp.

This also adds a `response-content-disposition` arg that when called will call the appropriate `ResponseContentDisposition` (aws-specific), and `response_disposition` (gcp-specific) kwargs.

A test has been added to ensure that `generate_presigned_GET_url()` returns the `Content-Disposition` expected.